### PR TITLE
Fix SecurityQuestionSeeder fatal error (remove invalid return and broken translations)

### DIFF
--- a/database/seeders/SecurityQuestionSeeder.php
+++ b/database/seeders/SecurityQuestionSeeder.php
@@ -20,9 +20,7 @@
 namespace Database\Seeders;
 
 use App\Models\Admin\SecurityQuestion;
-use App\Models\Personalization\Translation;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\Schema;
 
 class SecurityQuestionSeeder extends Seeder
 {
@@ -45,24 +43,11 @@ class SecurityQuestionSeeder extends Seeder
         ];
 
         foreach ($questions as $question) {
-            $securityQuestion = SecurityQuestion::create([
+            SecurityQuestion::create([
                 'question' => $question['question'],
                 'is_active' => true,
                 'sort_order' => $question['sort_order'],
             ]);
-
-            foreach ($question['translations'] as $locale => $content) {
-                Translation::updateOrCreate([
-                    'model' => SecurityQuestion::class,
-                    'model_id' => $securityQuestion->id,
-                    'key' => 'question',
-                    'locale' => $locale,
-                ], [
-                    'content' => $content,
-                ]);
-            }
         }
-
-        return collect($locales)->mapWithKeys(fn (string $locale) => [$locale => $question])->toArray();
     }
 }


### PR DESCRIPTION
### Motivation
- The seeder caused a PHP fatal error `A void function must not return a value` because `run(): void` returned a value at the end of the method. 
- The seeder referenced missing/unused keys and code (`$question['translations']`, `$locales`, and `Translation` usage) that made the logic incorrect and fragile during `php artisan migrate --seed`.

### Description
- Removed the invalid `return` statement from `run(): void` and eliminated the code that attempted to return a collection. 
- Deleted the broken translations block that iterated ` $question['translations']` and used `Translation::updateOrCreate`, and removed the related unused import. 
- Simplified creation to call `SecurityQuestion::create(...)` for each entry so the seeder only inserts the default security questions (file: `database/seeders/SecurityQuestionSeeder.php`).

### Testing
- Ran `php -l database/seeders/SecurityQuestionSeeder.php` which reported no syntax errors and thus passed. 
- Attempted `php artisan db:seed --class=Database\\Seeders\\SecurityQuestionSeeder --no-interaction --no-ansi` which could not be executed in this environment due to missing dependencies (`vendor/autoload.php`), so seeding could not be fully validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c8c8a938832897ed200923c21437)